### PR TITLE
Ajout du openhack sept 2014

### DIFF
--- a/_data/openhack-events.yml
+++ b/_data/openhack-events.yml
@@ -1,3 +1,9 @@
+- title: Septembre 2014 - SQIL
+  date: "Mardi 23 sept, à 18h00"
+  eventbrite_id: 13224628219
+  location: "Coq Rôti, Jonquière, 2407, rue St-Dominique"
+  sponsor: "Par hasard ça tombe durant la Semaine Québecoise de l'Informatique Libre aussi bien le souligner"
+
 - title: "OpenHack d'été: bière, BBQ, piscine et code à Alma!"
   date: "Mardi 15 juillet, à 18h00"
   eventbrite_id: 12264179491


### PR DESCRIPTION
Openhack 2014 en même temps que la Semaine Québecoise de l'Informatique Libre (SQIL)
