### PR TITLE
Fixes gh-pages build warning about pygments highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,4 +7,5 @@ author:
 markdown:     redcarpet
 permalink:    pretty
 pygments:     true
+highlighter:  rouge
 paginate:     5


### PR DESCRIPTION
The page build completed successfully, but returned the following
warning for the `gh-pages` branch:

You are attempting to use the 'pygments' highlighter, which is currently
unsupported on GitHub Pages. Your site will use 'rouge' for highlighting
instead. To suppress this warning, change the 'highlighter' value to
'rouge' in your '_config.yml' and ensure the 'pygments' key is unset.
For more information, see
https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.

For information on troubleshooting Jekyll see:

 https://help.github.com/articles/troubleshooting-jekyll-builds

 If you have any questions you can contact us by replying to this email.