### PR TITLE
Fix responsive breakpoints

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -34,7 +34,7 @@
 				grid: ( gutters: (50px, 50px) )
 			),
 			tablet: (
-				containers: 1000px,
+				containers: 730px,
 				grid: ( gutters: (35px, 35px) )
 			),
 			mobile: (
@@ -709,10 +709,6 @@
 				letter-spacing: 0.025em;
 			}
 
-			body {
-				min-width: 1200px;
-			}
-
 			hr {
 				margin: 2em 0 2em 0;
 			}
@@ -1080,7 +1076,6 @@
 
 				> .style3 {
 					font-size: 1.1em;
-					width: 48em;
 					margin: 0 auto;
 				}
 			}
@@ -1172,7 +1167,6 @@
 		/* Basic */
 
 			body {
-				min-width: 1000px;
 				font-size: 12pt;
 				line-height: 1.5em;
 				letter-spacing: 0.015em;
@@ -1182,10 +1176,6 @@
 				font-size: 12pt;
 				line-height: 1.5em;
 				letter-spacing: 0.015em;
-			}
-
-			body {
-				min-width: 960px;
 			}
 
 		/* Wrappers */


### PR DESCRIPTION
Les valeurs par défaut des breakpoints et le css hardcodé, c'était n'importe quoi :)
Enlever les `min-width` pour le body et mettre des valeurs qui font du sens dans `skel` semble arranger le responsive 🌮 

before:
<img width="864" alt="before" src="https://user-images.githubusercontent.com/1264761/31644485-a68203be-b2c4-11e7-834b-fd8d914ce4fa.png">
after:
<img width="864" alt="after" src="https://user-images.githubusercontent.com/1264761/31644486-a69a35ba-b2c4-11e7-9387-10710d35a528.png">
