### PR TITLE
Fix header-wrapper::before overlay using negative z-index

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -34,7 +34,7 @@
 				grid: ( gutters: (50px, 50px) )
 			),
 			tablet: (
-				containers: 1000px,
+				containers: 730px,
 				grid: ( gutters: (35px, 35px) )
 			),
 			mobile: (
@@ -709,10 +709,6 @@
 				letter-spacing: 0.025em;
 			}
 
-			body {
-				min-width: 1200px;
-			}
-
 			hr {
 				margin: 2em 0 2em 0;
 			}
@@ -1080,7 +1076,6 @@
 
 				> .style3 {
 					font-size: 1.1em;
-					width: 48em;
 					margin: 0 auto;
 				}
 			}
@@ -1172,7 +1167,6 @@
 		/* Basic */
 
 			body {
-				min-width: 1000px;
 				font-size: 12pt;
 				line-height: 1.5em;
 				letter-spacing: 0.015em;
@@ -1182,10 +1176,6 @@
 				font-size: 12pt;
 				line-height: 1.5em;
 				letter-spacing: 0.015em;
-			}
-
-			body {
-				min-width: 960px;
 			}
 
 		/* Wrappers */

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -535,6 +535,7 @@
 	#header-wrapper {
 		background: url('../../images/banner.png') center center;
 		background-size: cover;
+		z-index: -2;
 
 		&:before {
 			content: '';
@@ -543,6 +544,7 @@
 			left: 0;
 			width: 100%;
 			height: 100%;
+			z-index: -1;
 			background-image: url('images/overlay.png'), linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.6));
 		}
 	}


### PR DESCRIPTION
[`z-index` has lower browser compatibility](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index), but we should be ok with that.

Before:
<img width="592" alt="before" src="https://user-images.githubusercontent.com/1264761/31645212-d180d406-b2c8-11e7-8f33-0270d7673bc8.png">
After:
<img width="592" alt="after" src="https://user-images.githubusercontent.com/1264761/31645210-d16709ea-b2c8-11e7-920d-529620f54964.png">

