### PR TITLE
Moves manual fixes back to custom css & fix logo positionning with bigger header

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -4,11 +4,19 @@
 
 #logo {
     height: auto;
-    top: 30%;
+    top: 145px;
 }
 
 .logo {
     max-width: 150px;
+}
+
+#header-wrapper {
+    z-index: -2;
+    height: 400px;
+    &:before {
+        z-index: -1;
+    }
 }
 
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -534,7 +534,6 @@
 	#header-wrapper {
 		background: url('../../images/banner.png') center center;
 		background-size: cover;
-		z-index: -2;
 
 		&:before {
 			content: '';
@@ -543,7 +542,6 @@
 			left: 0;
 			width: 100%;
 			height: 100%;
-			z-index: -1;
 			background-image: url('images/overlay.png'), linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.6));
 		}
 	}


### PR DESCRIPTION
Logo seems to display correctly with these values in place for each responsive breakpoints.

<img width="701" alt="image" src="https://user-images.githubusercontent.com/1264761/31648832-dd400fd6-b2dd-11e7-97d9-5122724e1c94.png">
