### PR TITLE
Fix featured list title aligment for desktop #133

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -25,6 +25,21 @@
     }
 }
 
+@include breakpoint(desktop) {
+    /* Feature List */
+    .feature-list {
+        h3 {
+            position: relative;
+            padding: 4px 0 0 90px;
+
+            &:before {
+                left: 0;
+                position: absolute;
+            }
+        }
+    }
+}
+
 // fix logo and title display with nav
 #header-wrapper {
     height: 400px;


### PR DESCRIPTION
Related to issue #133 

## Description

Fix featured list title aligment for desktop, when need more than 1 line

![fixfeaturedlisttitlealigment](https://user-images.githubusercontent.com/7308580/32105241-c869e92c-baf5-11e7-8765-580f1a8eb326.PNG)

